### PR TITLE
Refactor/spherical orbit camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ To explore and learn both [Odin](https://odin-lang.org/) and 3D rendering and co
 ## Goals
 - [x] Render vertices as points (respecting z-index)
 - [x] Render cubes using indexed drawing
-- [ ] Move to MVP translation matrices
+- [ ] Move to MVP translation matrices in shader
+- [x] Camera rotation with spherical coordinates
 - [ ] Render edges as lines (respecting z-index)
 - [ ] Render coordinate axes
 - [ ] Add perspective to renders

--- a/src/render/camera.odin
+++ b/src/render/camera.odin
@@ -5,35 +5,23 @@ import "core:fmt"
 import glm "core:math/linalg/glsl"
 
 // Camera properties.
-camera_position: glm.vec3 = {1., 1., 1.}
+camera_position_cartesian: glm.vec3 = get_cartesian_coordinates({1.5, 1.5, 1.5})
+camera_position_spherical: glm.vec3 = get_spherical_coordinates(camera_position_cartesian)
 camera_target: glm.vec3 = {0., 0., 0.}
-camera_direction := -glm.normalize(camera_position)
-camera_speed: f32 = 0.05
+
+// bound of theta to avoid going upside down
+theta_bound :: (glm.PI / 2.0) - 0.00001
+
+// rates of rotation and zoom
+rotation_rate :: 0.1
+zoom_rate :: 0.1
 
 // Direction vectors.
-world_front: glm.vec3 = {0., 0., -1.}
 world_up: glm.vec3 = {0., 1., 0.}
-camera_right: glm.vec3 = glm.normalize(glm.cross(world_up, camera_direction))
-
-scaled_delta_angle: f32 = delta_angle * 1e5
-accumulated_angle: f32
-
-camera_y_clockwise_rotation_matrix := glm.mat4Rotate({0., 1., 0.}, -scaled_delta_angle)
-camera_y_cclockwise_rotation_matrix := glm.mat4Rotate({0., 1., 0.}, scaled_delta_angle)
-camera_xz_positive_rotation_matrix := glm.mat4Rotate(camera_right, scaled_delta_angle)
-camera_xz_negative_rotation_matrix := glm.mat4Rotate(camera_right, -scaled_delta_angle)
 
 // Used for the actual vertex transformation.
-camera_view_matrix := glm.mat4LookAt(camera_position, camera_target, world_up)
+camera_view_matrix := glm.mat4LookAt(camera_position_cartesian, camera_target, world_up)
 
 update_camera :: proc() {
-	camera_direction = -glm.normalize(camera_position)
-	camera_right = glm.normalize(glm.cross(world_up, camera_direction))
-	scaled_delta_angle = delta_angle * 1e5
-
-	camera_y_clockwise_rotation_matrix = glm.mat4Rotate({0., 1., 0.}, -scaled_delta_angle)
-	camera_y_cclockwise_rotation_matrix = glm.mat4Rotate({0., 1., 0.}, scaled_delta_angle)
-	camera_xz_positive_rotation_matrix = glm.mat4Rotate(camera_right, scaled_delta_angle)
-	camera_xz_negative_rotation_matrix = glm.mat4Rotate(camera_right, -scaled_delta_angle)
+	camera_view_matrix = glm.mat4LookAt(get_cartesian_coordinates(camera_position_spherical), camera_target, world_up)
 }
-

--- a/src/render/gl.odin
+++ b/src/render/gl.odin
@@ -13,7 +13,6 @@ Vertex :: struct {
 }
 
 update :: proc(vertices: []Vertex, uniforms: map[string]gl.Uniform_Info) {
-	camera_view_matrix = glm.mat4LookAt(camera_position, camera_target, world_up)
 	proj := glm.mat4Perspective(glm.radians_f32(45), 1.3, 0.1, 100.0)
 	scale := f32(0.3)
 	model := glm.mat4{scale, 0., 0., 0., 0., scale, 0., 0., 0., 0., scale, 0., 0., 0., 0., 1}

--- a/src/render/spherical.odin
+++ b/src/render/spherical.odin
@@ -1,0 +1,37 @@
+package render
+
+import glm "core:math/linalg/glsl"
+
+// equations here will differ from wikipedia due to a difference in conventions
+// https://en.wikipedia.org/wiki/Spherical_coordinate_system#Cartesian_coordinates
+
+// equations were found from: https://nerdhut.de/2020/05/09/unity-arcball-camera-spherical-coordinates/
+// NOTE: assumes Unity uses the same coordinate system
+
+// from empirical testing, phi may be backwards (depending on convention), however, it results
+// in correct behavior if negated
+
+// vec3 of { radius, phi, theta }
+get_spherical_coordinates :: proc(cartesian: glm.vec3) -> (spherical: glm.vec3) {
+    spherical[0] = glm.length(cartesian) // radius
+    spherical[1] = glm.atan2(cartesian.z / cartesian.x, cartesian.x) // phi
+    spherical[2] = glm.acos(cartesian.y / spherical[0]) // theta
+
+    if cartesian.x < 0 {
+        spherical[1] += glm.PI
+    }
+
+    return
+}
+
+get_cartesian_coordinates :: proc(spherical: glm.vec3) -> (cartesian: glm.vec3) {
+    radius := spherical[0]
+    phi := spherical[1]
+    theta := spherical[2]
+
+    cartesian.x = radius * glm.cos(theta) * glm.cos(phi)
+    cartesian.y = radius * glm.sin(theta)
+    cartesian.z = radius * glm.cos(theta) * glm.sin(phi)
+
+    return
+}

--- a/src/render/window.odin
+++ b/src/render/window.odin
@@ -70,28 +70,27 @@ mamino_exit :: proc() {
 }
 
 key_callback :: proc "c" (window: glfw.WindowHandle, key, scancode, action, mods: i32) {
-	accumulated_angle += scaled_delta_angle
-
 	if key == glfw.KEY_ESCAPE || key == glfw.KEY_Q {
 		running = false
 	}
+
 	if key == glfw.KEY_W || key == glfw.KEY_UP {
-		camera_position = glm.mat3(camera_xz_positive_rotation_matrix) * camera_position
+		camera_position_spherical.z = glm.clamp(camera_position_spherical.z + rotation_rate, -theta_bound, theta_bound)
 	}
 	if key == glfw.KEY_S || key == glfw.KEY_DOWN {
-		camera_position = glm.mat3(camera_xz_negative_rotation_matrix) * camera_position
+		camera_position_spherical.z = glm.clamp(camera_position_spherical.z - rotation_rate, -theta_bound, theta_bound)
 	}
 	if key == glfw.KEY_A || key == glfw.KEY_LEFT {
-		camera_position = glm.mat3(camera_y_clockwise_rotation_matrix) * camera_position
+		camera_position_spherical.y += rotation_rate
 	}
 	if key == glfw.KEY_D || key == glfw.KEY_RIGHT {
-		camera_position = glm.mat3(camera_y_cclockwise_rotation_matrix) * camera_position
+		camera_position_spherical.y -= rotation_rate
 	}
 	if key == glfw.KEY_EQUAL {
-		camera_position += scaled_delta_angle * camera_speed * camera_direction
+		camera_position_spherical.x -= zoom_rate
 	}
 	if key == glfw.KEY_MINUS {
-		camera_position -= scaled_delta_angle * camera_speed * camera_direction
+		camera_position_spherical.x += zoom_rate
 	}
 }
 


### PR DESCRIPTION
Refactored camera controls to use spherical coordinates. Due to a convention difference, the equations used will differ from [Wikipedia](https://en.wikipedia.org/wiki/Spherical_coordinate_system#Cartesian_coordinates). The equations were found from: [How to program an arcball (orbiting) camera in Unity using spherical coordinates](https://nerdhut.de/2020/05/09/unity-arcball-camera-spherical-coordinates/). This does assume that OpenGL works in the same coordinate system that Unity does. Empirical testing shows phi's definition may be negated (depending on convention). However, negating the rotation rate for phi results in the desired behavior.