### PR TITLE
Feature: Foundations for Animations

### DIFF
--- a/src/debugger.odin
+++ b/src/debugger.odin
@@ -92,9 +92,7 @@ debugger_get_most_recent_framerate :: proc(debugger: ^Debugger) -> f64 {
 	return 1. / debugger.frametimes[len(debugger.frametimes) - 1]
 }
 
-render_debugger :: proc(debugger: ^Debugger, render_objects: ^[]union {
-		objects.Cube,
-	}, render_objects_info: ^[]objects.ObjectInfo) {
+render_debugger :: proc(debugger: ^Debugger, render_objects: ^[]objects.Object, render_objects_info: ^[]objects.ObjectInfo) {
 	context.allocator = context.temp_allocator
 
 	imgl.NewFrame()
@@ -133,11 +131,9 @@ render_debugger :: proc(debugger: ^Debugger, render_objects: ^[]union {
 		debug_object_display_with_id = {debug_list_item, object_info.id}
 		append(&debug_objects_display, debug_object_display_with_id)
 	}
-	highlighted_debug_object: union {
-		objects.Cube,
-	}
-	for obj in render_objects {
-		if objects.get_object_info(obj).id == render.highlighted_debug_object_id {
+	highlighted_debug_object: objects.Object
+	for &obj in render_objects {
+		if objects.get_object_info(&obj).id == render.highlighted_debug_object_id {
 			highlighted_debug_object = obj
 			break
 		}
@@ -237,9 +233,7 @@ debugger_render_debug_objects_list :: proc(
 		cstring,
 		objects.ObjectID,
 	},
-	highlighted_debug_object: union {
-		objects.Cube,
-	},
+	highlighted_debug_object: objects.Object,
 ) {
 	context.allocator = context.temp_allocator
 

--- a/src/main.odin
+++ b/src/main.odin
@@ -1,5 +1,3 @@
-#+feature dynamic-literals
-
 package main
 
 import "core:c"
@@ -25,6 +23,7 @@ import "render"
 import "sequencing"
 
 MAMINO_EXPORT_VIDEO :: #config(MAMINO_EXPORT_VIDEO, false)
+MAMINO_DEBUGGER :: #config(MAMINO_DEBUGGER_ENABLE, false)
 
 main :: proc() {
 	when ODIN_DEBUG {
@@ -52,25 +51,37 @@ main :: proc() {
 	// Init.
 	render.mamino_init()
 	window := render.mamino_create_window()
-	render.mamino_init_imgui(window)
+
+	// render.mamino_init_imgui(window)
+	render.highlighted_debug_object_id = ~objects.ObjectID(0)
+	
 	program_id, uniforms := render.mamino_init_gl()
 	when MAMINO_EXPORT_VIDEO {
 		sequencing.mamino_frame_capture_init()
 	}
 
+	scene := render.create_scene()
+
+	cube1 := objects.create_cube()
+
+	render.add_object(&scene, &cube1)
+
 	// Setup scene objects.
-	render_objects: []union {
-		objects.Cube,
-	} =
-		{objects.Cube{id = 0, center = {1., 1., 1.}, scale = {3., 1., 1.}, orientation = {glm.vec3{0., 1., 0.}, glm.radians(f32(45.))}}, objects.Cube{id = 1, center = {-1., 1., -1.}, scale = {1., 2., 1.}, orientation = {glm.vec3{1., 1., 1.}, glm.radians(f32(35.))}}, objects.Cube{id = 2, center = {0., 3., 2.}, scale = {0.5, 0.5, 0.5}, orientation = {glm.vec3{1., 0., 0.}, glm.radians(f32(60.))}}}
-	render_objects_info: []objects.ObjectInfo = objects.get_objects_info(render_objects)
+	// render_objects := scene.objects
+		// {objects.Cube{id = 0, center = {1., 1., 1.}, scale = {3., 1., 1.}, orientation = {glm.vec3{0., 1., 0.}, glm.radians(f32(45.))}}, objects.Cube{id = 1, center = {-1., 1., -1.}, scale = {1., 2., 1.}, orientation = {glm.vec3{1., 1., 1.}, glm.radians(f32(35.))}}, objects.Cube{id = 2, center = {0., 3., 2.}, scale = {0.5, 0.5, 0.5}, orientation = {glm.vec3{1., 0., 0.}, glm.radians(f32(60.))}}}
+	render_objects_info: []objects.ObjectInfo = objects.get_objects_info(scene.objects)
 
 	// Init debugger.
-	debugger: ^Debugger = &{}
-	mamino_init_debugger(debugger, render_objects)
+	when MAMINO_DEBUGGER {
+		debugger: ^Debugger = &{}
+		mamino_init_debugger(debugger, render_objects)
+	}
 
 	for (!glfw.WindowShouldClose(window) && render.running) {
-		debugger_update(debugger)
+
+		when MAMINO_DEBUGGER {
+			debugger_update(debugger)
+		}
 
 		// Set background.
 		gl.Clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT)
@@ -82,7 +93,7 @@ main :: proc() {
 		// Update (rotate) the vertices every frame.
 		render.update_shader(uniforms)
 
-		render.render_objects(&render_objects)
+		render.render_scene(&scene)
 		if render.render_axes {
 			render.render_coordinate_axes()
 		}
@@ -90,9 +101,12 @@ main :: proc() {
 			render.render_subgrid_axes()
 		}
 
-		if ODIN_DEBUG && render.debugger_open {
-			render_debugger(debugger, &render_objects, &render_objects_info)
+		when MAMINO_DEBUGGER {
+			if ODIN_DEBUG && render.debugger_open {
+				render_debugger(debugger, &render_objects, &render_objects_info)
+			}
 		}
+
 		when MAMINO_EXPORT_VIDEO {
 			sequencing.mamino_capture_frame()
 		}
@@ -104,10 +118,12 @@ main :: proc() {
 	}
 	glfw.DestroyWindow(window)
 
-	avg_framerate := debugger_calculate_avg_fps(debugger.frametimes)
-	fmt.println("Average:", avg_framerate, "FPS")
-	low_framerate := debugger_calculate_percent_low_fps(debugger.frametimes)
-	fmt.println("Percent low:", low_framerate, "FPS")
+	when MAMINO_DEBUGGER {
+		avg_framerate := debugger_calculate_avg_fps(debugger.frametimes)
+		fmt.println("Average:", avg_framerate, "FPS")
+		low_framerate := debugger_calculate_percent_low_fps(debugger.frametimes)
+		fmt.println("Percent low:", low_framerate, "FPS")
+	}
 
 	video_options: sequencing.VideoOptions = {
 			resolution = {1920, 1080},

--- a/src/main.odin
+++ b/src/main.odin
@@ -62,13 +62,67 @@ main :: proc() {
 
 	scene := render.create_scene()
 
-	cube1 := objects.create_cube()
-
+	cube1 := objects.create_cube(
+		center = {1., 1., 1.},
+		starting_scale = {3., 1., 1.},
+		starting_orientation = {
+			{0., 1., 0.},
+			glm.radians(f32(35.)),
+		},
+	)
 	render.add_object(&scene, &cube1)
 
+	cube2 := objects.create_cube(
+		center = {-1., 1., -1.}, 
+		starting_scale = {1., 2., 1.}, 
+		starting_orientation = {
+			{1., 1., 1.}, 
+			glm.radians(f32(35.)),
+		}
+	)
+	render.add_object(&scene, &cube2)
+
+	cube3 := objects.create_cube(
+		center = {0., 3., 2.}, 
+		starting_scale = {0.5, 0.5, 0.5}, 
+		starting_orientation = {
+			{1., 0., 0.}, 
+			glm.radians(f32(60.)),
+		}
+	)
+	render.add_object(&scene, &cube3)
+
 	// Setup scene objects.
-	// render_objects := scene.objects
-		// {objects.Cube{id = 0, center = {1., 1., 1.}, scale = {3., 1., 1.}, orientation = {glm.vec3{0., 1., 0.}, glm.radians(f32(45.))}}, objects.Cube{id = 1, center = {-1., 1., -1.}, scale = {1., 2., 1.}, orientation = {glm.vec3{1., 1., 1.}, glm.radians(f32(35.))}}, objects.Cube{id = 2, center = {0., 3., 2.}, scale = {0.5, 0.5, 0.5}, orientation = {glm.vec3{1., 0., 0.}, glm.radians(f32(60.))}}}
+	// render_objects :=
+	// {
+	// 	objects.Cube{
+	// 		id = 0, 
+	// 		center = {1., 1., 1.}, 
+	// 		scale = {3., 1., 1.}, 
+	// 		orientation = {
+	// 			glm.vec3{0., 1., 0.}, 
+	// 			glm.radians(f32(45.))
+	// 		}
+	// 	}, 
+	// 	objects.Cube{
+	// 		id = 1, 
+	// 		center = {-1., 1., -1.}, 
+	// 		scale = {1., 2., 1.}, 
+	// 		orientation = {
+	// 			glm.vec3{1., 1., 1.}, 
+	// 			glm.radians(f32(35.))
+	// 		}
+	// 	}, 
+	// 	objects.Cube{
+	// 		id = 2, 
+	// 		center = {0., 3., 2.}, 
+	// 		scale = {0.5, 0.5, 0.5}, 
+	// 		orientation = {
+	// 			glm.vec3{1., 0., 0.}, 
+	// 			glm.radians(f32(60.))
+	// 		}
+	// 	}
+	// }
 	render_objects_info: []objects.ObjectInfo = objects.get_objects_info(scene.objects)
 
 	// Init debugger.

--- a/src/main.odin
+++ b/src/main.odin
@@ -52,8 +52,12 @@ main :: proc() {
 	render.mamino_init()
 	window := render.mamino_create_window()
 
-	// render.mamino_init_imgui(window)
 	render.highlighted_debug_object_id = ~objects.ObjectID(0)
+
+	when MAMINO_DEBUGGER {
+		render.mamino_init_imgui(window)
+		render.highlighted_debug_object_id = 0
+	}
 	
 	program_id, uniforms := render.mamino_init_gl()
 	when MAMINO_EXPORT_VIDEO {
@@ -62,35 +66,49 @@ main :: proc() {
 
 	scene := render.create_scene()
 
-	cube1 := objects.create_cube(
-		center = {1., 1., 1.},
-		starting_scale = {3., 1., 1.},
-		starting_orientation = {
-			{0., 1., 0.},
-			glm.radians(f32(35.)),
+	cube := objects.create_cube()
+	render.add_object(&scene, &cube)
+	objects.add_key_frame(&cube, 
+		scale = objects.Scale {
+			1., 2., 1.,
 		},
 	)
-	render.add_object(&scene, &cube1)
-
-	cube2 := objects.create_cube(
-		center = {-1., 1., -1.}, 
-		starting_scale = {1., 2., 1.}, 
-		starting_orientation = {
-			{1., 1., 1.}, 
-			glm.radians(f32(35.)),
-		}
+	objects.add_key_frame(&cube, 
+		orientation = objects.Orientation {
+			norm = {1., 0., 0.,}, 
+			angle = glm.radians(f32(45.))
+		},
 	)
-	render.add_object(&scene, &cube2)
 
-	cube3 := objects.create_cube(
-		center = {0., 3., 2.}, 
-		starting_scale = {0.5, 0.5, 0.5}, 
-		starting_orientation = {
-			{1., 0., 0.}, 
-			glm.radians(f32(60.)),
-		}
-	)
-	render.add_object(&scene, &cube3)
+	// cube1 := objects.create_cube(
+	// 	center = {1., 1., 1.},
+	// 	starting_scale = {3., 1., 1.},
+	// 	starting_orientation = {
+	// 		{0., 1., 0.},
+	// 		glm.radians(f32(35.)),
+	// 	},
+	// )
+	// render.add_object(&scene, &cube1)
+
+	// cube2 := objects.create_cube(
+	// 	center = {-1., 1., -1.}, 
+	// 	starting_scale = {1., 2., 1.}, 
+	// 	starting_orientation = {
+	// 		{1., 1., 1.}, 
+	// 		glm.radians(f32(35.)),
+	// 	}
+	// )
+	// render.add_object(&scene, &cube2)
+
+	// cube3 := objects.create_cube(
+	// 	center = {0., 3., 2.}, 
+	// 	starting_scale = {0.5, 0.5, 0.5}, 
+	// 	starting_orientation = {
+	// 		{1., 0., 0.}, 
+	// 		glm.radians(f32(60.)),
+	// 	}
+	// )
+	// render.add_object(&scene, &cube3)
 
 	// Setup scene objects.
 	// render_objects :=
@@ -132,6 +150,9 @@ main :: proc() {
 	}
 
 	for (!glfw.WindowShouldClose(window) && render.running) {
+
+		// NOTE(Jaran): temporary "public" API to modify keyframes
+		objects.set_current_key_frame(&cube, render.current_key_frame)
 
 		when MAMINO_DEBUGGER {
 			debugger_update(debugger)

--- a/src/objects/cube.odin
+++ b/src/objects/cube.odin
@@ -7,13 +7,13 @@ Cube :: struct {
 	// Geometric center.
 	id:          ObjectID,
 	center:      glm.vec3,
-	key_frames: [dynamic]Frame,
+	key_frames: [dynamic]KeyFrame,
 	current_key_frame: uint,
 }
 
 create_cube :: proc(center: glm.vec3 = {0., 0., 0.}, starting_scale: Scale = {1., 1., 1.}, starting_orientation: Orientation = {norm = {1., 0., 0.,}, angle = 0.}) -> Object {
-	key_frames := make([dynamic]Frame)
-	append(&key_frames, Frame { scale = starting_scale, orientation = starting_orientation })
+	key_frames := make([dynamic]KeyFrame)
+	append(&key_frames, KeyFrame { scale = starting_scale, orientation = starting_orientation })
 	cube := Cube {
 		id = current_object_id,
 		center = center,

--- a/src/objects/cube.odin
+++ b/src/objects/cube.odin
@@ -11,6 +11,21 @@ Cube :: struct {
 	current_key_frame: uint,
 }
 
+create_cube :: proc(center: glm.vec3 = {0., 0., 0.}, starting_scale: Scale = {1., 1., 1.}, starting_orientation: Orientation = {norm = {1., 0., 0.,}, angle = 0.}) -> Object {
+	key_frames := make([dynamic]Frame)
+	append(&key_frames, Frame { scale = starting_scale, orientation = starting_orientation })
+	cube := Cube {
+		id = current_object_id,
+		center = center,
+		key_frames = key_frames,
+		current_key_frame = 0,
+	}
+
+	current_object_id += 1
+
+	return cube
+}
+
 get_cube_vertices :: proc(cube: Cube) -> (vertices: []Vertex) {
 	vertices = make([]Vertex, len(cube_vertices), context.temp_allocator)
 	copy(vertices, cube_vertices)

--- a/src/objects/cube.odin
+++ b/src/objects/cube.odin
@@ -7,19 +7,23 @@ Cube :: struct {
 	// Geometric center.
 	id:          ObjectID,
 	center:      glm.vec3,
-	scale:       Scale,
-	orientation: Orientation,
+	key_frames: [dynamic]Frame,
+	current_key_frame: uint,
 }
 
 get_cube_vertices :: proc(cube: Cube) -> (vertices: []Vertex) {
 	vertices = make([]Vertex, len(cube_vertices), context.temp_allocator)
 	copy(vertices, cube_vertices)
+	
+	scale := cube.key_frames[cube.current_key_frame].scale
+	orientation := cube.key_frames[cube.current_key_frame].orientation
+	
 	for &vertex in vertices {
-		vertex.position.x *= cube.scale.x
-		vertex.position.y *= cube.scale.y
-		vertex.position.z *= cube.scale.z
+		vertex.position.x *= scale.x
+		vertex.position.y *= scale.y
+		vertex.position.z *= scale.z
 
-		rotation_matrix := glm.mat4Rotate(cube.orientation.norm, cube.orientation.angle)
+		rotation_matrix := glm.mat4Rotate(orientation.norm, orientation.angle)
 		vertex_pos_as_vec4 := glm.vec4 {
 			vertex.position.x,
 			vertex.position.y,
@@ -38,18 +42,21 @@ get_cube_normals_coordinates :: proc(cube: Cube) -> (normals: []Vertex) {
 	standard_y_axis: glm.vec4 = {0., 1., 0., 0.}
 	standard_z_axis: glm.vec4 = {0., 0., 1., 0.}
 
-	rotation_matrix := glm.mat4Rotate(cube.orientation.norm, cube.orientation.angle)
+	scale := cube.key_frames[cube.current_key_frame].scale
+	orientation := cube.key_frames[cube.current_key_frame].orientation
+
+	rotation_matrix := glm.mat4Rotate(orientation.norm, orientation.angle)
 	rotated_x_axis: glm.vec3 = (rotation_matrix * standard_x_axis).xyz
 	rotated_y_axis: glm.vec3 = (rotation_matrix * standard_y_axis).xyz
 	rotated_z_axis: glm.vec3 = (rotation_matrix * standard_z_axis).xyz
 
 	// Addition of a glm.vec3 so the endpoints stick above the faces by a defined amount.
 	rotated_x_normal: glm.vec3 =
-		(rotation_matrix * standard_x_axis).xyz * cube.scale.x + rotated_x_axis
+		(rotation_matrix * standard_x_axis).xyz * scale.x + rotated_x_axis
 	rotated_y_normal: glm.vec3 =
-		(rotation_matrix * standard_y_axis).xyz * cube.scale.y + rotated_y_axis
+		(rotation_matrix * standard_y_axis).xyz * scale.y + rotated_y_axis
 	rotated_z_normal: glm.vec3 =
-		(rotation_matrix * standard_z_axis).xyz * cube.scale.z + rotated_z_axis
+		(rotation_matrix * standard_z_axis).xyz * scale.z + rotated_z_axis
 
 	x_normal_color := x_axis_color
 	y_normal_color := y_axis_color

--- a/src/objects/generic_data.odin
+++ b/src/objects/generic_data.odin
@@ -23,7 +23,7 @@ Orientation :: struct {
 	angle: f32,
 }
 
-Frame :: struct {
+KeyFrame :: struct {
 	scale: Scale,
 	orientation: Orientation,
 }
@@ -54,7 +54,7 @@ add_key_frame :: proc(object: ^Object, scale: Maybe(Scale) = nil, orientation: M
 	#partial switch &generic_object in object {
 		case Cube:
 			last_index := len(generic_object.key_frames) - 1
-			append(&generic_object.key_frames, Frame { scale = scale.? or_else generic_object.key_frames[last_index].scale, orientation = orientation.? or_else generic_object.key_frames[last_index].orientation })
+			append(&generic_object.key_frames, KeyFrame { scale = scale.? or_else generic_object.key_frames[last_index].scale, orientation = orientation.? or_else generic_object.key_frames[last_index].orientation })
 		case:
 			return
 	}

--- a/src/objects/generic_data.odin
+++ b/src/objects/generic_data.odin
@@ -41,19 +41,23 @@ ObjectInfo :: struct {
 @(private)
 current_object_id: ObjectID = 0
 
-create_cube :: proc(center: glm.vec3 = {0., 0., 0.}, starting_scale: Scale = {1., 1., 1.}, starting_orientation: Orientation = {norm = {1., 0., 0.,}, angle = 0.}) -> Object {
-	key_frames := make([dynamic]Frame)
-	append(&key_frames, Frame { scale = starting_scale, orientation = starting_orientation })
-	cube := Cube {
-		id = current_object_id,
-		center = center,
-		key_frames = key_frames,
-		current_key_frame = 0,
+set_current_key_frame :: proc(object: ^Object, frame_index: uint) {
+	#partial switch &generic_object in object {
+		case Cube:
+			generic_object.current_key_frame = frame_index % len(generic_object.key_frames)
+		case:
+			return
 	}
+}
 
-	current_object_id += 1
-
-	return cube
+add_key_frame :: proc(object: ^Object, scale: Maybe(Scale) = nil, orientation: Maybe(Orientation) = nil) {
+	#partial switch &generic_object in object {
+		case Cube:
+			last_index := len(generic_object.key_frames) - 1
+			append(&generic_object.key_frames, Frame { scale = scale.? or_else generic_object.key_frames[last_index].scale, orientation = orientation.? or_else generic_object.key_frames[last_index].orientation })
+		case:
+			return
+	}
 }
 
 get_vertices :: proc {

--- a/src/objects/generic_data.odin
+++ b/src/objects/generic_data.odin
@@ -23,10 +23,37 @@ Orientation :: struct {
 	angle: f32,
 }
 
+Frame :: struct {
+	scale: Scale,
+	orientation: Orientation,
+}
+
+Object :: union {
+	Cube,
+}
+
 ObjectID :: distinct uint
 ObjectInfo :: struct {
 	type: string,
 	id:   ObjectID,
+}
+
+@(private)
+current_object_id: ObjectID = 0
+
+create_cube :: proc(center: glm.vec3 = {0., 0., 0.}, starting_scale: Scale = {1., 1., 1.}, starting_orientation: Orientation = {norm = {1., 0., 0.,}, angle = 0.}) -> Object {
+	key_frames := make([dynamic]Frame)
+	append(&key_frames, Frame { scale = starting_scale, orientation = starting_orientation })
+	cube := Cube {
+		id = current_object_id,
+		center = center,
+		key_frames = key_frames,
+		current_key_frame = 0,
+	}
+
+	current_object_id += 1
+
+	return cube
 }
 
 get_vertices :: proc {
@@ -39,9 +66,7 @@ color_vertices :: proc(vertices: ^[]Vertex, color: glm.vec4 = {1., 1., 1., 1.}) 
 	}
 }
 
-get_object_id :: proc(object: union {
-		Cube,
-	}) -> ObjectID {
+get_object_id :: proc(object: Object) -> ObjectID {
 	#partial switch generic_object in object {
 	case Cube:
 		return generic_object.id
@@ -50,9 +75,7 @@ get_object_id :: proc(object: union {
 	}
 }
 
-get_object_type_string :: proc(object: union {
-		Cube,
-	}) -> (object_type: string) {
+get_object_type_string :: proc(object: Object) -> (object_type: string) {
 	#partial switch generic_object in object {
 	case Cube:
 		object_type = "Cube"
@@ -62,9 +85,7 @@ get_object_type_string :: proc(object: union {
 	return
 }
 
-get_object_center :: proc(object: union {
-		Cube,
-	}) -> (center: glm.vec3) {
+get_object_center :: proc(object: Object) -> (center: glm.vec3) {
 	#partial switch generic_object in object {
 	case Cube:
 		center = generic_object.center
@@ -73,43 +94,35 @@ get_object_center :: proc(object: union {
 	return
 }
 
-get_object_scale :: proc(object: union {
-		Cube,
-	}) -> (scale: Scale) {
+get_object_scale :: proc(object: Object) -> (scale: Scale) {
 	#partial switch generic_object in object {
 	case Cube:
-		scale = generic_object.scale
+		scale = generic_object.key_frames[generic_object.current_key_frame].scale
 	case:
 	}
 
 	return
 }
 
-get_object_orientation :: proc(object: union {
-		Cube,
-	}) -> (orientation: Orientation) {
+get_object_orientation :: proc(object: Object) -> (orientation: Orientation) {
 	#partial switch generic_object in object {
 	case Cube:
-		orientation = generic_object.orientation
+		orientation = generic_object.key_frames[generic_object.current_key_frame].orientation
 	case:
 	}
 
 	return
 }
 
-get_object_info :: proc(object: union {
-		Cube,
-	}) -> (object_info: ObjectInfo) {
-	object_info.type = get_object_type_string(object)
-	object_info.id = ObjectID(get_object_id(object))
+get_object_info :: proc(object: ^Object) -> (object_info: ObjectInfo) {
+	object_info.type = get_object_type_string(object^)
+	object_info.id = ObjectID(get_object_id(object^))
 
 	return
 }
 
-get_objects_info :: proc(objects: []union {
-		Cube,
-	}) -> (objects_info: []ObjectInfo) {
-	objects_info = slice.mapper(objects, get_object_info)
+get_objects_info :: proc(objects: [dynamic]^Object) -> (objects_info: []ObjectInfo) {
+	objects_info = slice.mapper(objects[:], get_object_info)
 
 	return
 }

--- a/src/render/scene.odin
+++ b/src/render/scene.odin
@@ -14,9 +14,20 @@ render_grid: bool = true
 
 HIGHLIGHTED_OBJECT_COLOR :: glm.vec4{0.15, 0.83, 1.0, 0.5}
 
-render_objects :: proc(render_objects: ^[]union {
-		objects.Cube,
-	}) {
+Scene :: struct {
+	objects: [dynamic]^objects.Object
+}
+
+create_scene :: proc() -> Scene {
+	return Scene {}
+}
+
+add_object :: proc(scene: ^Scene, object: ^objects.Object) {
+	append(&scene.objects, object)
+}
+
+render_scene :: proc(scene: ^Scene) {
+	render_objects := scene.objects
 	for generic_object in render_objects {
 		#partial switch object in generic_object {
 		case objects.Cube:

--- a/src/render/window.odin
+++ b/src/render/window.odin
@@ -95,10 +95,16 @@ mamino_destroy_window :: proc(window: glfw.WindowHandle) {
 	// free(window)
 }
 
+current_key_frame: uint = 0
+
 key_callback :: proc "c" (window: glfw.WindowHandle, key, scancode, action, mods: i32) {
 	switch key {
 	case glfw.KEY_ESCAPE, glfw.KEY_Q:
 		running = false
+	case glfw.KEY_E:
+		if action == glfw.PRESS {
+			current_key_frame += 1
+		}
 	case glfw.KEY_W, glfw.KEY_UP:
 		camera_position_spherical.z = glm.clamp(
 			camera_position_spherical.z + rotation_rate,


### PR DESCRIPTION
Refactored from the low-level object slice API to a higher-level scene-oriented API. Per #7, the API closely follows the proposed Odin-style API (which follows conventions seen in the Odin base and core packages). Furthermore, this PR introduces a keyframing system that allows Mamino users to specify the scale and orientation of objects as keyframes of the object's animation. Currently, pressing the `E` key will cycle through these keyframes. Interpolation between keyframes will be implemented in a follow-up PR with an accompanying issue.